### PR TITLE
fix: improve address intake

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -41,6 +41,8 @@ ENDPOINT = 'azure' # set to 'local' if you wish to run locally using personal Op
 
 ENDPOINT_AZURE = "https://ai-openai-ont.openai.azure.com/"
 
+ENDPOINT_BAG = "https://api.data.amsterdam.nl/v1/dataverkenner/bagadresinformatie/bagadresinformatie/"
+
 model_dict = {"ChatGPT 4o": "gpt-4o"}
 summarize_melding_for_policy_retrieval = False # set to True if you wish to summarize melding for policy retrieval
 

--- a/src/helpers/melding_helpers.py
+++ b/src/helpers/melding_helpers.py
@@ -8,6 +8,7 @@ from langchain_core.prompts import ChatPromptTemplate
 
 import config as cfg
 import my_secrets
+import requests
 
 def get_melding_attributes(melding, attribute, model_name, chat_history):
     """
@@ -48,6 +49,23 @@ def get_melding_attributes(melding, attribute, model_name, chat_history):
     # Load and update attributes based on response
     response_data = json.loads(completion.choices[0].message.content)
     return response_data if response_data else {}
+
+def get_additional_address_info(melding):
+    """
+    Use the provided postcode and huisnummer to obtain straatnaam from the bag api
+    """
+    url = cfg.ENDPOINT_BAG
+    params = {"postcode": melding.melding_attributes.get('POSTCODE'),
+                "huisnummer": melding.melding_attributes.get('HUISNUMMER')}
+    response = requests.get(url, params = params)
+
+    if response.status_code == 200:
+        data = response.json()
+        if data:
+            if data['_embedded']['bagadresinformatie'][0]['openbareruimteNaam']:
+                return data['_embedded']['bagadresinformatie'][0]['openbareruimteNaam']
+    else:
+        return ""
 
 def select_prompt_template(attribute):
     """

--- a/src/process_melding.py
+++ b/src/process_melding.py
@@ -164,18 +164,6 @@ class MeldingProcessor:
         self.melding_attributes['INITIAL_RESPONSE'] = completion.choices[0].message.content
 
 
-    # def _build_address_prompt(self):
-    #     """
-    #     Build a prompt to request missing address information from the user.
-    #     """
-    #     if not self.melding_attributes.get('STRAATNAAM'):
-    #         return "Kan je me de straatnaam geven waar je het probleem ervaart?"
-    #     if not self.melding_attributes.get('HUISNUMMER'):
-    #         return "Wat is het huisnummer?"
-    #     if not self.melding_attributes.get('POSTCODE'):
-    #         return "Wat is de postcode?"
-    #     return None
-
     def _build_address_prompt(self):
         """
         Build a prompt to request missing address information from the user.
@@ -200,9 +188,6 @@ class MeldingProcessor:
             'HUISNUMMER': self.melding_attributes.get('HUISNUMMER', ''),
             'POSTCODE': self.melding_attributes.get('POSTCODE', '')
         }
-
-        print(f"Het address is\n {self.melding_attributes['ADDRESS']}")
-
 
     def _melding_requires_license_plate(self):
         """

--- a/src/process_melding.py
+++ b/src/process_melding.py
@@ -9,7 +9,8 @@ from helpers.melding_helpers import (
     get_melding_attributes, 
     generate_image_caption,
     add_chat_response,
-    get_additional_address_info
+    get_additional_address_info,
+    check_postcode_format
 )
 
 import config as cfg
@@ -171,9 +172,9 @@ class MeldingProcessor:
         if self.melding_attributes.get('POSTCODE') and not self.melding_attributes.get('HUISNUMMER'):
             return "Bedankt voor de postcode, wat is het huisnummer?"
         if self.melding_attributes.get('HUISNUMMER') and not self.melding_attributes.get('POSTCODE'):
-            return "Bedankt voor het huisnummer, wat is de postcode?"
+            return "Bedankt voor het huisnummer, wat is de postcode (in format 9999XX)?"
         if not self.melding_attributes.get('POSTCODE') or not self.melding_attributes.get('HUISNUMMER'):
-            return "Kan je me de postcode en het huisnummer geven van het adres waar je het probleem ervaart?"
+            return "Kan je me de postcode (in format 9999XX) en het huisnummer geven van het adres waar je het probleem ervaart?"
         return None
 
     def _generate_address(self):

--- a/src/process_melding.py
+++ b/src/process_melding.py
@@ -8,11 +8,13 @@ from langchain_core.prompts import ChatPromptTemplate
 from helpers.melding_helpers import (
     get_melding_attributes, 
     generate_image_caption,
-    add_chat_response
+    add_chat_response,
+    get_additional_address_info
 )
 
 import config as cfg
 import my_secrets
+import re
 
 # Environment setup
 os.environ['KMP_DUPLICATE_LIB_OK'] = 'True'
@@ -161,27 +163,46 @@ class MeldingProcessor:
 
         self.melding_attributes['INITIAL_RESPONSE'] = completion.choices[0].message.content
 
+
+    # def _build_address_prompt(self):
+    #     """
+    #     Build a prompt to request missing address information from the user.
+    #     """
+    #     if not self.melding_attributes.get('STRAATNAAM'):
+    #         return "Kan je me de straatnaam geven waar je het probleem ervaart?"
+    #     if not self.melding_attributes.get('HUISNUMMER'):
+    #         return "Wat is het huisnummer?"
+    #     if not self.melding_attributes.get('POSTCODE'):
+    #         return "Wat is de postcode?"
+    #     return None
+
     def _build_address_prompt(self):
         """
         Build a prompt to request missing address information from the user.
         """
-        if not self.melding_attributes.get('STRAATNAAM'):
-            return "Kan je me de straatnaam geven waar je het probleem ervaart?"
-        if not self.melding_attributes.get('HUISNUMMER'):
-            return "Wat is het huisnummer?"
-        if not self.melding_attributes.get('POSTCODE'):
-            return "Wat is de postcode?"
+        if self.melding_attributes.get('POSTCODE') and not self.melding_attributes.get('HUISNUMMER'):
+            return "Bedankt voor de postcode, wat is het huisnummer?"
+        if self.melding_attributes.get('HUISNUMMER') and not self.melding_attributes.get('POSTCODE'):
+            return "Bedankt voor het huisnummer, wat is de postcode?"
+        if not self.melding_attributes.get('POSTCODE') or not self.melding_attributes.get('HUISNUMMER'):
+            return "Kan je me de postcode en het huisnummer geven van het adres waar je het probleem ervaart?"
         return None
 
     def _generate_address(self):
         """
         Generate a complete address for the melding using available attributes.
         """
+        self.melding_attributes['STRAATNAAM'] = get_additional_address_info(self)
+        self.melding_attributes['HUISNUMMER'] = re.match(r'^\d+', self.melding_attributes.get('HUISNUMMER', '')).group()
+
         self.melding_attributes['ADDRESS'] = {
             'STRAATNAAM': self.melding_attributes.get('STRAATNAAM', ''),
             'HUISNUMMER': self.melding_attributes.get('HUISNUMMER', ''),
             'POSTCODE': self.melding_attributes.get('POSTCODE', '')
         }
+
+        print(f"Het address is\n {self.melding_attributes['ADDRESS']}")
+
 
     def _melding_requires_license_plate(self):
         """


### PR DESCRIPTION
Fix to improve address intake:
- Added a helper function to `melding_helpers.py` to retrieve `STRAATNAAM` based on `POSTCODE` and `HUISNUMMER`
- `process_melding.py` now requests the `POSTCODE` and `HUISNUMMER` in one prompt, if the user provides either, it requests the additional through a new prompt
- `HUISNUMMER` gets truncated to the base number before creating `ADDRESS` to prevent house "letters" (e.g. 150-B) to be part of `HUISNUMMER` to improve API compatibility